### PR TITLE
check first if value can be converted to Bool

### DIFF
--- a/ios/LeanplumTypeUtils.swift
+++ b/ios/LeanplumTypeUtils.swift
@@ -13,10 +13,10 @@ class LeanplumTypeUtils {
     static func createVar(key: String, value: Any) -> Var? {
         var lpVar: Var
         switch value.self {
-        case is Int, is Double, is Float:
-            lpVar = Var(name: key, double: value as? Double ?? 0.0)
         case is Bool:
             lpVar = Var(name: key, boolean: value as? Bool ?? false)
+        case is Int, is Double, is Float:
+            lpVar = Var(name: key, double: value as? Double ?? 0.0)
         case is String:
             lpVar = Var(name: key, string: value as? String)
         case is Array<Any>:

--- a/ios/LeanplumTypeUtils.swift
+++ b/ios/LeanplumTypeUtils.swift
@@ -13,6 +13,13 @@ class LeanplumTypeUtils {
     static func createVar(key: String, value: Any) -> Var? {
         var lpVar: Var
         switch value.self {
+        case is NSNumber:
+            let tmp = value as? NSNumber ?? 0
+            if isBoolNumber(num: tmp) {
+                lpVar = Var(name: key, boolean: value as? Bool ?? false)
+            } else {
+                lpVar = Var(name: key, double: value as? Double ?? 0.0)
+            }
         case is Bool:
             lpVar = Var(name: key, boolean: value as? Bool ?? false)
         case is Int, is Double, is Float:
@@ -72,4 +79,9 @@ class LeanplumTypeUtils {
         return messageDataDict
        }
 
+    private static func isBoolNumber(num: NSNumber) -> Bool {
+        let boolID = CFBooleanGetTypeID()
+        let numID = CFGetTypeID(num)
+        return numID == boolID
+    }
 }


### PR DESCRIPTION
JIRA Issue: https://leanplum.atlassian.net/browse/SDK-212

Problem was when in Bool is coming as NSNumber with boolean literal value in iOS wrapper. In this case first we were checking if this value can be converted to number (Int, Float, Double) and since it is a NSNumber it is converting this Bool to 0 or 1.
Solution: First check if the value can be converted to Bool. With this we will be sure if NSNumber has boolean literal as a value it will be saved as Bool.