### PR TITLE
Do not remove element from traversed collection

### DIFF
--- a/android/src/main/java/com/leanplum/rn/utils/MapUtil.java
+++ b/android/src/main/java/com/leanplum/rn/utils/MapUtil.java
@@ -118,7 +118,6 @@ public class MapUtil {
         while (iterator.hasNext()) {
             Map.Entry pair = (Map.Entry) iterator.next();
             writableMap.merge(addValue((String) pair.getKey(), pair.getValue()));
-            iterator.remove();
         }
 
         return writableMap;


### PR DESCRIPTION
Removing an element from the backing collection was causing the `Var`'s value to be edited by the user. The best practice is to return a copied collection when `Var.value()` is invoked, which can be fixed only from the native SDKs, but it is also wrong and unnecessary to directly edit the returned collection.